### PR TITLE
feat: enable manual pdf downloads

### DIFF
--- a/public/manuals/README.md
+++ b/public/manuals/README.md
@@ -1,0 +1,3 @@
+# Manuals Directory
+
+Place PDF files for manuals in this folder. The sample files included are placeholders.

--- a/public/manuals/advanced-features.pdf
+++ b/public/manuals/advanced-features.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 144]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 24 Tf 100 100 Td (Hello PDF) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000122 00000 n 
+0000000273 00000 n 
+0000000355 00000 n 
+trailer<</Size 6/Root 1 0 R>>
+startxref
+419
+%%EOF

--- a/public/manuals/api-documentation.pdf
+++ b/public/manuals/api-documentation.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 144]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 24 Tf 100 100 Td (Hello PDF) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000122 00000 n 
+0000000273 00000 n 
+0000000355 00000 n 
+trailer<</Size 6/Root 1 0 R>>
+startxref
+419
+%%EOF

--- a/public/manuals/installation-guide.pdf
+++ b/public/manuals/installation-guide.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 144]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 24 Tf 100 100 Td (Hello PDF) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000122 00000 n 
+0000000273 00000 n 
+0000000355 00000 n 
+trailer<</Size 6/Root 1 0 R>>
+startxref
+419
+%%EOF

--- a/public/manuals/product-manual.pdf
+++ b/public/manuals/product-manual.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 144]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 24 Tf 100 100 Td (Hello PDF) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000122 00000 n 
+0000000273 00000 n 
+0000000355 00000 n 
+trailer<</Size 6/Root 1 0 R>>
+startxref
+419
+%%EOF

--- a/public/manuals/security-guidelines.pdf
+++ b/public/manuals/security-guidelines.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 144]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 24 Tf 100 100 Td (Hello PDF) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000122 00000 n 
+0000000273 00000 n 
+0000000355 00000 n 
+trailer<</Size 6/Root 1 0 R>>
+startxref
+419
+%%EOF

--- a/public/manuals/troubleshooting.pdf
+++ b/public/manuals/troubleshooting.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 144]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 24 Tf 100 100 Td (Hello PDF) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000122 00000 n 
+0000000273 00000 n 
+0000000355 00000 n 
+trailer<</Size 6/Root 1 0 R>>
+startxref
+419
+%%EOF

--- a/src/app/manual/[id]/page.tsx
+++ b/src/app/manual/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, use, useRef } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { 
   ChevronLeft, 
   ChevronRight, 
@@ -12,13 +12,12 @@ import {
   ZoomOut,
   RotateCcw,
   Star,
-  Clock,
   Eye,
   Maximize2,
   Minimize2
 } from 'lucide-react';
 import Link from 'next/link';
-import FlipBook from '@/components/FlipBook';
+import FlipBook, { FlipBookRef } from '@/components/FlipBook';
 
 interface Page {
   id: number;
@@ -176,13 +175,13 @@ export default function ManualPage({ params }: { params: Promise<{ id: string }>
   const [zoom, setZoom] = useState(140);
   const [manual, setManual] = useState<Manual | null>(null);
   const [loading, setLoading] = useState(true);
-  const flipRef = useRef<any>(null);
+  const flipRef = useRef<FlipBookRef | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
 
   useEffect(() => {
     setTimeout(() => {
-      setManual(sampleManual);
+      setManual({ ...sampleManual, id });
       setLoading(false);
     }, 400);
   }, [id]);
@@ -211,14 +210,20 @@ export default function ManualPage({ params }: { params: Promise<{ id: string }>
   const prevPage = () => flipRef.current?.flipPrev?.();
 
   const handleDownload = async () => {
-    if (manual) {
-      try {
-        console.log(`Downloading ${manual.title}`);
-        alert(`${manual.title} 다운로드가 시작됩니다.`);
-      } catch (error) {
-        console.error('다운로드 오류:', error);
-        alert('다운로드 중 오류가 발생했습니다.');
-      }
+    if (!manual) return;
+    try {
+      const res = await fetch(`/api/download/${manual.id}`);
+      if (!res.ok) throw new Error('Download link not found');
+      const json = await res.json();
+      const link = document.createElement('a');
+      link.href = json.data.downloadUrl;
+      link.download = `${json.data.title}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } catch (error) {
+      console.error('다운로드 오류:', error);
+      alert('다운로드 중 오류가 발생했습니다.');
     }
   };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -106,10 +106,17 @@ export default function Home() {
     return matchesCategory && matchesSearch;
   });
 
-  const handleDownload = async (pdfUrl: string, title: string) => {
+  const handleDownload = async (manualId: string, title: string) => {
     try {
-      console.log(`Downloading ${title} from ${pdfUrl}`);
-      alert(`${title} 다운로드가 시작됩니다.`);
+      const res = await fetch(`/api/download/${manualId}`);
+      if (!res.ok) throw new Error('Download link not found');
+      const json = await res.json();
+      const link = document.createElement('a');
+      link.href = json.data.downloadUrl;
+      link.download = `${title}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
     } catch (error) {
       console.error('다운로드 오류:', error);
       alert('다운로드 중 오류가 발생했습니다.');
@@ -312,7 +319,7 @@ export default function Home() {
                       
                       <div className="flex space-x-3">
                         <button
-                          onClick={() => handleDownload(manual.pdfUrl, manual.title)}
+                          onClick={() => handleDownload(manual.id, manual.title)}
                           className="flex-1 flex items-center justify-center space-x-2 px-4 py-3 bg-gradient-to-r from-blue-500 to-purple-600 text-white font-medium rounded-xl hover:from-blue-600 hover:to-purple-700 transition-all duration-300 transform hover:scale-105"
                         >
                           <Download className="w-4 h-4" />

--- a/src/components/FlipBook.tsx
+++ b/src/components/FlipBook.tsx
@@ -8,13 +8,18 @@ export interface FlipPageData {
   content: string;
 }
 
+export interface FlipBookRef {
+  flipNext: () => void;
+  flipPrev: () => void;
+}
+
 interface FlipBookProps {
   pages: FlipPageData[];
   scalePercent: number; // 50 - 200
   onFlip?: (pageIndex: number) => void;
 }
 
-const FlipBook = forwardRef<any, FlipBookProps>(({ pages, scalePercent, onFlip }, ref) => {
+const FlipBook = forwardRef<FlipBookRef, FlipBookProps>(({ pages, scalePercent, onFlip }, ref) => {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const [dims, setDims] = useState({ w: 1200, h: 800 });
 
@@ -45,7 +50,7 @@ const FlipBook = forwardRef<any, FlipBookProps>(({ pages, scalePercent, onFlip }
       <div className="pointer-events-none absolute inset-y-0 left-1/2 -translate-x-1/2 w-24 bg-gradient-to-r from-black/10 via-transparent to-black/10 opacity-40 z-10" />
 
       <HTMLFlipBook
-        ref={ref}
+        ref={ref as unknown as React.Ref<unknown>}
         width={dims.w}
         height={dims.h}
         size="fixed"
@@ -58,7 +63,7 @@ const FlipBook = forwardRef<any, FlipBookProps>(({ pages, scalePercent, onFlip }
         showCover={false}
         drawShadow
         className="rounded-2xl shadow-2xl overflow-hidden bg-neutral-200"
-        onFlip={(e: any) => onFlip?.(e.data)}
+        onFlip={(e: { data: number }) => onFlip?.(e.data)}
         flippingTime={700}
       >
         {pages.map((page, index) => {


### PR DESCRIPTION
## Summary
- hook up manual list and viewer download buttons to fetch real PDF links
- load manual data using route id and add typed flipbook refs
- include placeholder manuals under `public/manuals`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a77dc91e248327bf297b641a52e45b